### PR TITLE
Added reference to Docker labs

### DIFF
--- a/labs/extra-exercises/secrets.md
+++ b/labs/extra-exercises/secrets.md
@@ -89,3 +89,7 @@ Cleanup the service, secret and leave swarm mode:
 ## Slides (later)
 
 High level overview - why secrets, diagram of how
+
+## Additonal exercises
+
+* [Docker lab on secrets](https://github.com/docker/labs/tree/master/security/secrets)


### PR DESCRIPTION
Although the Docker labs are referenced from the README.md in the root, I think it merits to link to the specific labs when we have a katas that covers the same area.